### PR TITLE
fix: update `lol_dba` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.1)
-    lol_dba (1.6.1)
+    lol_dba (1.6.4)
       actionpack (>= 3.0)
       activerecord (>= 3.0)
       railties (>= 3.0)


### PR DESCRIPTION
There was an exception raised when a model contained enums caused by double loading of models (see [lol_dba#39](https://github.com/plentz/lol_dba/issues/39) for more informations).

This issue has been addressed in [this
PR](https://github.com/plentz/lol_dba/pull/40) and pushed in `lol_dba`
`1.6.3`.
